### PR TITLE
Fix exception when host is clicked but tooltip was never shown

### DIFF
--- a/projects/ng2-tooltip-directive/src/lib/tooltip.directive.ts
+++ b/projects/ng2-tooltip-directive/src/lib/tooltip.directive.ts
@@ -230,7 +230,7 @@ export class TooltipDirective {
     @HostListener('click')
     onClick() {
         if (this.isDisplayOnClick == false) {
-            this.componentRef.destroy();
+            this.componentRef?.destroy();
             return;
         }
 


### PR DESCRIPTION
In our application, tooltips are only displayed under certain circumstances. They are hidden via the `display` property of the `TooltipOptions`. This probably causes `this.componentRef` to be undefined, which causes an error on the changed line.
This can be solved by only calling `destroy()` if `componentRef` is not empty.
